### PR TITLE
Added Workspace Quick Switcher

### DIFF
--- a/ArmA.Studio/App.xaml.cs
+++ b/ArmA.Studio/App.xaml.cs
@@ -126,6 +126,16 @@ namespace ArmA.Studio
             }
             var workspace = dlgDc.CurrentPath;
             ConfigHost.App.WorkspacePath = workspace;
+
+            //Save new Workspace to Prev Workspace List
+            List<string> prevWorkSpaces = ConfigHost.App.PrevWorkspacePath;
+            if (prevWorkSpaces.Contains(workspace))
+            {
+                prevWorkSpaces.Remove(workspace);
+            }
+            prevWorkSpaces.Insert(0, workspace);
+            ConfigHost.App.PrevWorkspacePath = prevWorkSpaces;
+
             return true;
         }
 

--- a/ArmA.Studio/App.xaml.cs
+++ b/ArmA.Studio/App.xaml.cs
@@ -134,6 +134,11 @@ namespace ArmA.Studio
                 prevWorkSpaces.Remove(workspace);
             }
             prevWorkSpaces.Insert(0, workspace);
+            int numSpaces = 5;
+            if(prevWorkSpaces.Count > numSpaces)
+            {
+                prevWorkSpaces.RemoveRange(numSpaces, (prevWorkSpaces.Count- numSpaces));
+            }
             ConfigHost.App.PrevWorkspacePath = prevWorkSpaces;
 
             return true;

--- a/ArmA.Studio/App.xaml.cs
+++ b/ArmA.Studio/App.xaml.cs
@@ -127,20 +127,6 @@ namespace ArmA.Studio
             var workspace = dlgDc.CurrentPath;
             ConfigHost.App.WorkspacePath = workspace;
 
-            //Save new Workspace to Prev Workspace List
-            List<string> prevWorkSpaces = ConfigHost.App.PrevWorkspacePath;
-            if (prevWorkSpaces.Contains(workspace))
-            {
-                prevWorkSpaces.Remove(workspace);
-            }
-            prevWorkSpaces.Insert(0, workspace);
-            int numSpaces = 5;
-            if(prevWorkSpaces.Count > numSpaces)
-            {
-                prevWorkSpaces.RemoveRange(numSpaces, (prevWorkSpaces.Count- numSpaces));
-            }
-            ConfigHost.App.PrevWorkspacePath = prevWorkSpaces;
-
             return true;
         }
 

--- a/ArmA.Studio/ConfigHost.cs
+++ b/ArmA.Studio/ConfigHost.cs
@@ -56,6 +56,26 @@ namespace ArmA.Studio
                 set { Instance.AppIni.SetValue(nameof(App), nameof(Workspace), value); Instance.Save(EIniSelector.App); }
             }
 
+            public static List<string> PrevWorkspacePath
+            {
+                get {
+                    string s = Instance.AppIni.GetValueOrNull(nameof(App), nameof(PrevWorkspacePath));
+                    string[] pathArray = new string[0];
+                    if (!(s == null))
+                    {
+                        pathArray = s.Split(',');
+                    }
+                    
+                    return new List<string>(pathArray);
+                }
+                set {
+                    string s = string.Join(",", value.ToArray());
+
+                    Instance.AppIni.SetValue(nameof(App), nameof(PrevWorkspacePath), s);
+                    Instance.Save(EIniSelector.App);
+                }
+            }
+
             public static bool ErrorList_IsErrorsDisplayed
             {
                 get { bool val; if (bool.TryParse(Instance.AppIni.GetValueOrNull(nameof(DataContext.ErrorListPane), nameof(DataContext.ErrorListPane.IsErrorsDisplayed)), out val)) return val; return true; }

--- a/ArmA.Studio/ConfigHost.cs
+++ b/ArmA.Studio/ConfigHost.cs
@@ -63,6 +63,7 @@ namespace ArmA.Studio
                     string[] pathArray = new string[0];
                     if (!(s == null))
                     {
+                        s = s.Replace(" ", "");
                         pathArray = s.Split(',');
                     }
                     

--- a/ArmA.Studio/ConfigHost.cs
+++ b/ArmA.Studio/ConfigHost.cs
@@ -58,7 +58,8 @@ namespace ArmA.Studio
 
             public static List<string> PrevWorkspacePath
             {
-                get {
+                get
+                {
                     string s = Instance.AppIni.GetValueOrNull(nameof(App), nameof(PrevWorkspacePath));
                     string[] pathArray = new string[0];
                     if (!(s == null))
@@ -69,7 +70,8 @@ namespace ArmA.Studio
                     
                     return new List<string>(pathArray);
                 }
-                set {
+                set
+                {
                     string s = string.Join(",", value.ToArray());
 
                     Instance.AppIni.SetValue(nameof(App), nameof(PrevWorkspacePath), s);

--- a/ArmA.Studio/Dialogs/WorkspaceSelectorDialog.xaml
+++ b/ArmA.Studio/Dialogs/WorkspaceSelectorDialog.xaml
@@ -23,7 +23,7 @@
         <Button Grid.Row="0" Grid.Column="2" Content="{x:Static p:Localization.WorkspaceSelectorDialog_Browse}" Padding="8 0" MinWidth="100" Command="{Binding CmdBrowse}"/>
 
         <Label Grid.Row="1" Content="{x:Static p:Localization.WorkspaceSelectorDialog_SelectPrev}"></Label>
-        <ListBox Grid.Row="2" Grid.ColumnSpan="3" ItemsSource="{Binding WorkSpaceListBox}" SelectedItem="{Binding WorkSpaceListBoxSelectedItem}" >
+        <ListBox Grid.Row="2" Grid.ColumnSpan="3" ItemsSource="{Binding WorkSpaceListBox}" SelectedItem="{Binding CurrentPath}" >
             
         </ListBox>
     </Grid>

--- a/ArmA.Studio/Dialogs/WorkspaceSelectorDialog.xaml
+++ b/ArmA.Studio/Dialogs/WorkspaceSelectorDialog.xaml
@@ -7,14 +7,25 @@
         xmlns:p="clr-namespace:ArmA.Studio.Properties"
         xmlns:att="clr-namespace:ArmA.Studio.UI.Attached"
         mc:Ignorable="d"
-        Title="{x:Static p:Localization.WorkspaceSelectorDialog_Title}" Height="210" Style="{StaticResource DialogWindow}">
+        Title="{x:Static p:Localization.WorkspaceSelectorDialog_Title}" Height="322" Style="{StaticResource DialogWindow}">
     <Grid VerticalAlignment="Center">
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition Height="80" />
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="8"/>
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" IsReadOnly="True" Text="{Binding CurrentPath, UpdateSourceTrigger=PropertyChanged}" Foreground="Gray"/>
-        <Button Grid.Column="2" Content="{x:Static p:Localization.WorkspaceSelectorDialog_Browse}" Padding="8 0" MinWidth="100" Command="{Binding CmdBrowse}"/>
+        <TextBox Grid.Row="0" Grid.Column="0" IsReadOnly="True" Text="{Binding CurrentPath, UpdateSourceTrigger=PropertyChanged}" Foreground="Gray"/>
+        <Button Grid.Row="0" Grid.Column="2" Content="{x:Static p:Localization.WorkspaceSelectorDialog_Browse}" Padding="8 0" MinWidth="100" Command="{Binding CmdBrowse}"/>
+
+        <Label Grid.Row="1">Select previous Workspace</Label>
+        <ListBox Grid.Row="2" Grid.ColumnSpan="3" ItemsSource="{Binding WorkSpaceListBox}" SelectedItem="{Binding WorkSpaceListBoxSelectedItem}" >
+            
+        </ListBox>
     </Grid>
+
 </Window>

--- a/ArmA.Studio/Dialogs/WorkspaceSelectorDialog.xaml
+++ b/ArmA.Studio/Dialogs/WorkspaceSelectorDialog.xaml
@@ -22,7 +22,7 @@
         <TextBox Grid.Row="0" Grid.Column="0" IsReadOnly="True" Text="{Binding CurrentPath, UpdateSourceTrigger=PropertyChanged}" Foreground="Gray"/>
         <Button Grid.Row="0" Grid.Column="2" Content="{x:Static p:Localization.WorkspaceSelectorDialog_Browse}" Padding="8 0" MinWidth="100" Command="{Binding CmdBrowse}"/>
 
-        <Label Grid.Row="1">Select previous Workspace</Label>
+        <Label Grid.Row="1" Content="{x:Static p:Localization.WorkspaceSelectorDialog_SelectPrev}"></Label>
         <ListBox Grid.Row="2" Grid.ColumnSpan="3" ItemsSource="{Binding WorkSpaceListBox}" SelectedItem="{Binding WorkSpaceListBoxSelectedItem}" >
             
         </ListBox>

--- a/ArmA.Studio/Dialogs/WorkspaceSelectorDialogDataContext.cs
+++ b/ArmA.Studio/Dialogs/WorkspaceSelectorDialogDataContext.cs
@@ -38,8 +38,6 @@ namespace ArmA.Studio.Dialogs
         public bool OKButtonEnabled { get { return this._OKButtonEnabled; } set { this._OKButtonEnabled = value; this.RaisePropertyChanged(); } }
         private bool _OKButtonEnabled;
 
-        public List<String> workSpaceList;
-
         public WorkspaceSelectorDialogDataContext()
         {
             this.CmdBrowse = new UI.Commands.RelayCommand(Cmd_Browse);

--- a/ArmA.Studio/Dialogs/WorkspaceSelectorDialogDataContext.cs
+++ b/ArmA.Studio/Dialogs/WorkspaceSelectorDialogDataContext.cs
@@ -22,9 +22,6 @@ namespace ArmA.Studio.Dialogs
         public List<String> WorkSpaceListBox { get { return this._WorkSpaceListBox;  } set { this._WorkSpaceListBox = value; this.RaisePropertyChanged(); } }
         private List<String> _WorkSpaceListBox;
 
-        public String WorkSpaceListBoxSelectedItem { get { return this._WorkSpaceListBoxSelectedItem; } set { this._WorkSpaceListBoxSelectedItem = value; this.RaisePropertyChanged();  this.WorkSpaceListBoxSelectionChanged(); } }
-        public String _WorkSpaceListBoxSelectedItem;
-
         public ICommand CmdBrowse { get; private set; }
         public ICommand CmdOKButtonPressed { get; private set; }
 
@@ -41,14 +38,30 @@ namespace ArmA.Studio.Dialogs
         public WorkspaceSelectorDialogDataContext()
         {
             this.CmdBrowse = new UI.Commands.RelayCommand(Cmd_Browse);
-            this.CmdOKButtonPressed = new UI.Commands.RelayCommand((p) => this.DialogResult = true);
+            this.CmdOKButtonPressed = new UI.Commands.RelayCommand(Cmd_Ok);
 
             this.WorkSpaceListBox = ConfigHost.App.PrevWorkspacePath;   
         }
 
-        public void WorkSpaceListBoxSelectionChanged()
+        public void Cmd_Ok(object param)
         {
-            this.CurrentPath = this.WorkSpaceListBoxSelectedItem;
+
+            //Save new Workspace to Prev Workspace List
+            List<string> prevWorkSpaces = ConfigHost.App.PrevWorkspacePath;
+            if (prevWorkSpaces.Contains(this.CurrentPath))
+            {
+                prevWorkSpaces.Remove(this.CurrentPath);
+            }
+            prevWorkSpaces.Insert(0, this.CurrentPath);
+            int numSpaces = 5;
+            if (prevWorkSpaces.Count > numSpaces)
+            {
+                prevWorkSpaces.RemoveRange(numSpaces, (prevWorkSpaces.Count - numSpaces));
+            }
+            ConfigHost.App.PrevWorkspacePath = prevWorkSpaces;
+
+            this.DialogResult = true;
+
         }
 
         public void Cmd_Browse(object param)

--- a/ArmA.Studio/Dialogs/WorkspaceSelectorDialogDataContext.cs
+++ b/ArmA.Studio/Dialogs/WorkspaceSelectorDialogDataContext.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Forms;
 using System.ComponentModel;
+using System.Windows.Controls;
 
 namespace ArmA.Studio.Dialogs
 {
@@ -17,6 +18,12 @@ namespace ArmA.Studio.Dialogs
 
         public string CurrentPath { get { return this._CurrentPath; } set { this._CurrentPath = value; this.OKButtonEnabled = !string.IsNullOrWhiteSpace(value); this.RaisePropertyChanged(); } }
         private string _CurrentPath;
+
+        public List<String> WorkSpaceListBox { get { return this._WorkSpaceListBox;  } set { this._WorkSpaceListBox = value; this.RaisePropertyChanged(); } }
+        private List<String> _WorkSpaceListBox;
+
+        public String WorkSpaceListBoxSelectedItem { get { return this._WorkSpaceListBoxSelectedItem; } set { this._WorkSpaceListBoxSelectedItem = value; this.RaisePropertyChanged();  this.WorkSpaceListBoxSelectionChanged(); } }
+        public String _WorkSpaceListBoxSelectedItem;
 
         public ICommand CmdBrowse { get; private set; }
         public ICommand CmdOKButtonPressed { get; private set; }
@@ -31,14 +38,23 @@ namespace ArmA.Studio.Dialogs
         public bool OKButtonEnabled { get { return this._OKButtonEnabled; } set { this._OKButtonEnabled = value; this.RaisePropertyChanged(); } }
         private bool _OKButtonEnabled;
 
+        public List<String> workSpaceList;
+
         public WorkspaceSelectorDialogDataContext()
         {
             this.CmdBrowse = new UI.Commands.RelayCommand(Cmd_Browse);
             this.CmdOKButtonPressed = new UI.Commands.RelayCommand((p) => this.DialogResult = true);
+
+            this.WorkSpaceListBox = ConfigHost.App.PrevWorkspacePath;   
         }
+
+        public void WorkSpaceListBoxSelectionChanged()
+        {
+            this.CurrentPath = this.WorkSpaceListBoxSelectedItem;
+        }
+
         public void Cmd_Browse(object param)
         {
-
             var cofd = new Microsoft.WindowsAPICodePack.Dialogs.CommonOpenFileDialog()
             {
                 IsFolderPicker = true,

--- a/ArmA.Studio/Properties/Localization.Designer.cs
+++ b/ArmA.Studio/Properties/Localization.Designer.cs
@@ -872,7 +872,18 @@ namespace ArmA.Studio.Properties {
                 return ResourceManager.GetString("WorkspaceSelectorDialog_Browse", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select Existing.
+        /// </summary>
+        public static string WorkspaceSelectorDialog_SelectPrev
+        {
+            get
+            {
+                return ResourceManager.GetString("WorkspaceSelectorDialog_SelectPrev", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Please select the folder where the project is located..
         /// </summary>

--- a/ArmA.Studio/Properties/Localization.resx
+++ b/ArmA.Studio/Properties/Localization.resx
@@ -398,7 +398,7 @@ Do you want to update now?</value>
     <value>Select Existing</value>
   </data>
   <data name="WorkspaceSelectorDialog_SelectPrev" xml:space="preserve">
-    <value>Last Workspaces</value>
+    <value>Recent</value>
   </data>
   <data name="WorkspaceSelectorDialog_Description" xml:space="preserve">
     <value>Please select the folder where the project is located.</value>

--- a/ArmA.Studio/Properties/Localization.resx
+++ b/ArmA.Studio/Properties/Localization.resx
@@ -397,6 +397,9 @@ Do you want to update now?</value>
   <data name="WorkspaceSelectorDialog_Browse" xml:space="preserve">
     <value>Select Existing</value>
   </data>
+  <data name="WorkspaceSelectorDialog_SelectPrev" xml:space="preserve">
+    <value>Last Workspaces</value>
+  </data>
   <data name="WorkspaceSelectorDialog_Description" xml:space="preserve">
     <value>Please select the folder where the project is located.</value>
   </data>


### PR DESCRIPTION
## Reason for PullRequest
Especially with the old Workspace File Dialog, but also with the new one, it was a little annoying to always search the Path of the Workspace you wanted to work in, so i added a List with the last 5 (configurable) workspaces a users has used for quick switching.

## Description of the Changes
Added a List Box to the WorkSpace Selector Dialog that Contains the last 5 used workspaces.
Clicking an Item results in it beeing put in the TextBox above and the "ok" button beeing enabled, pressing ok will then open the selected workspace.
[Screenshot](https://drive.google.com/uc?id=0B_TmB6GeWD7PUmNjb19ObWVJYXc)
## Notes
I have tested the changes with a clean install and also different data and everything seems to work fine.
I have tried to make all changes respecting the wpf mvvm scheme (and the general style of the application), but since i have never used it before there might be mistakes in that, if anything needs to be changed please let me know.