### PR TITLE
Timestamp in Output Panel

### DIFF
--- a/ArmA.Studio/DataContext/OutputPane.cs
+++ b/ArmA.Studio/DataContext/OutputPane.cs
@@ -37,7 +37,7 @@ namespace ArmA.Studio.DataContext
                     }
                 }
                 var doc = DocumentDictionary[e.Logger];
-                doc.Insert(doc.TextLength, string.Concat(e.Severity, ": ", e.Message, "\r\n"));
+                doc.Insert(doc.TextLength, string.Concat(DateTime.Now.ToString("HH:mm:ss")," - ",e.Severity, ": ", e.Message, "\r\n"));
             });
         }
         static OutputPane()


### PR DESCRIPTION
## Reason for PullRequest
Sometimes it is nice to see when a log entry was created e.g. when some error occured and you want to know if it is new or old.

## Description of the Changes
Adds a short Timestamp (HHmmss) to the Output Panel by concating it with the rest of the String in `OutputPane.cs`
[Screenshot](https://drive.google.com/uc?id=0B_TmB6GeWD7PTGZVaEdzcGx1RTA)

## Notes
NA